### PR TITLE
Allow commit message to be overridden by git config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ name and time by default.
 
 ## Options
 
-There are two `git config`-based options for tailoring your sync:
+There are three `git config`-based options for tailoring your sync:
 
     branch.$branch_name.syncNewFiles (bool)
     
@@ -102,6 +102,11 @@ Tells git-sync to invoke auto-commit even if new (untracked) files are
 present. Normally you have to commit those yourself to prevent
 accidential additions. git-sync will exit at stage 3 with an
 explanation in that case.
+
+    branch.$branch_name.syncCommitMsg (string)
+
+A string which will be used in place of the default commit message (as shown
+below).
 
     branch.$branch_name.autocommitscript (string)
 	

--- a/git-sync
+++ b/git-sync
@@ -35,10 +35,13 @@
 # succeed.
 
 # command used to auto-commit file modifications
-DEFAULT_AUTOCOMMIT_CMD="git add -u ; git commit -m \"changes from $(uname -n) on $(date)\";"
+DEFAULT_AUTOCOMMIT_CMD="git add -u ; git commit -m \"%message\";"
 
 # command used to auto-commit all changes
-ALL_AUTOCOMMIT_CMD="git add -A ; git commit -m \"changes from $(uname -n) on $(date)\";"
+ALL_AUTOCOMMIT_CMD="git add -A ; git commit -m \"%message\";"
+
+# default commit message substituted into autocommit commands
+DEFAULT_AUTOCOMMIT_MSG="changes from $(uname -n) on $(date)"
 
 
 # AUTOCOMMIT_CMD="echo \"Please commit or stash pending changes\"; exit 1;"
@@ -263,7 +266,13 @@ if [ ! -z "$(local_changes)" ]; then
     else
         autocommit_cmd=${DEFAULT_AUTOCOMMIT_CMD}
     fi
-    
+
+    commit_msg="$(git config --get branch.$branch_name.syncCommitMsg)"
+    if [ "" == "$commit_msg" ]; then
+      commit_msg=${DEFAULT_AUTOCOMMIT_MSG}
+    fi
+    autocommit_cmd=$(echo "$autocommit_cmd" | sed "s/%message/$commit_msg/")
+
     echo "git-sync: Committing local changes using ${autocommit_cmd}"
     eval $autocommit_cmd
 


### PR DESCRIPTION
As suggested in #3. This does not allow the commit message to be evaluated and means the default message is evaluated at beginning of script so in theory the date could be a second or two before the actually commit, but seems better than loads of escaping and weirdness.

I will be using this fork for some projects of mine where I want a static message.

Thoughts?
