### PR TITLE
Add $branch_name to `git fetch` to ensure extraneous branches are not fetched

### DIFF
--- a/git-sync
+++ b/git-sync
@@ -286,7 +286,7 @@ fi
 
 # fetch remote to get to the current sync state
 # TODO make fetching/pushing optional
-echo "git-sync: Fetching from $remote_name"
+echo "git-sync: Fetching from $remote_name/$branch_name"
 git fetch $remote_name $branch_name
 if [ $? != 0 ] ; then
     echo "git-sync: git fetch $remote_name returned non-zero. Likely a network problem; exiting."


### PR DESCRIPTION
A project I am working has a number of other branches besides the branch that is being synced using `git-sync`. Currently, all the other branches are needlessly fetched as soon as git fetch is run since it only includes the origin and not the specific branch. Assuming the repository was clone with `--branch` or has never had other branches fetched the data will not have been pulled, but git-sync insists on doing so.

This pull request simply adds the `$branch_name` to the `git fetch` call to ensure only the branch being synced is fetched.
