### PR TITLE
Adding descriptive help text for missing upstream

### DIFF
--- a/git-sync
+++ b/git-sync
@@ -206,6 +206,13 @@ remote_name=$(git config --get branch.$branch_name.remote)
 
 if [ -z "$remote_name" ] ; then
     echo "git-sync: the current branch does not have a configured remote."
+    echo
+    echo "git-sync: Please use"
+    echo
+    echo "  git branch --set-upstream-to=[remote_name]/$branch_name" 
+    echo
+    echo "replacing [remote_name] with the name of your remote, i.e. - origin"
+    echo "to set the remote tracking branch for git-sync to work"
     exit 2
 fi
 


### PR DESCRIPTION
Adding descriptive help text for missing upstream branch, instructing the user on what to do to correct the issue.

Example output:
```
21:38 $ git-sync check
git-sync: Preparing. Repo in .git
git-sync: the current branch does not have a configured remote.

git-sync: Please use

  git branch --set-upstream-to=[remote_name]/master

replacing [remote_name] with the name of your remote, i.e. - origin
to set the remote tracking branch for git-sync to work
```