### PR TITLE
Add git-sync-on-inotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Synchronize tracking repositories.
 
-This scrips intends to sync near-automatically via git 
+This scrips intends to sync near-automatically via git
 in "tracking" repositories where a nice history is not
 as crucial as having one.
 
@@ -102,7 +102,7 @@ name and time by default.
 There are three `git config`-based options for tailoring your sync:
 
     branch.$branch_name.syncNewFiles (bool)
-    
+
 Tells git-sync to invoke auto-commit even if new (untracked) files are
 present. Normally you have to commit those yourself to prevent
 accidential additions. git-sync will exit at stage 3 with an
@@ -114,7 +114,7 @@ A string which will be used in place of the default commit message (as shown
 below).
 
     branch.$branch_name.autocommitscript (string)
-	
+
 A string which is being eval'ed by this script to perform an
 auto-commit. Here you can run a commit script which should not
 leave any uncommited state. The default will commit modified or

--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ even if the matching `git config` option is not set.
 `-s` is the equivalent of `branch.$branch_name.sync`, allowing syncing a branch
 even if the matching `git config` option is not set.
 
+# git-sync-on-inotify
+
+Automatically synchronize your git repository whenever a file is touched.
+
+`git-sync-on-inotify` uses the functionality of `git-sync` together with an
+`inotifywait` to automatically synchronize local changes you have made to your
+files as soon as they happen. `inotifywait` waits for events from the operating
+system which are triggered by any edits you make to files in the git repository.
+This means that updates are near instantaneous, without the need to resort to
+polling. `git-sync-on-inotify` still does a polling call to `git-sync` to ensure that changes from the upstream do make it in. This polling interval is configurable with the environment variable `GIT_SYNC_INTERVAL`.
+
+
 # License
 
 I declare this work to be useable under the provisions of the CC0 license.

--- a/git-sync
+++ b/git-sync
@@ -180,7 +180,7 @@ sync_state()
 	    ;;
 	"0	0")
 	    echo "equal"
-	    true 
+	    true
 	    ;;
 	"0	"*)
 	    echo "ahead"
@@ -249,7 +249,7 @@ if [ -z "$remote_name" ] ; then
     echo
     __log_msg "Please use"
     echo
-    __log_msg "  git branch --set-upstream-to=[remote_name]/$branch_name" 
+    __log_msg "  git branch --set-upstream-to=[remote_name]/$branch_name"
     echo
     __log_msg "replacing [remote_name] with the name of your remote, i.e. - origin"
     __log_msg "to set the remote tracking branch for git-sync to work"
@@ -304,7 +304,7 @@ fi
 if [ ! -z "$(local_changes)" ]; then
     autocommit_cmd=""
     config_autocommit_cmd="$(git config --get branch.$branch_name.autocommitscript)"
-    
+
     # discern the three ways to auto-commit
     if [ ! -z "$config_autocommit_cmd" ]; then
 	autocommit_cmd="$config_autocommit_cmd"
@@ -382,4 +382,3 @@ case "$(sync_state)" in
 	# TODO: save master, if rebasing fails, make a branch of old master
 	;;
 esac
-

--- a/git-sync-on-inotify
+++ b/git-sync-on-inotify
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+GIT_SYNC_DIRECTORY="${GIT_SYNC_DIRECTORY:-$(pwd)}"
+GIT_SYNC_INTERVAL="${GIT_SYNC_INTERVAL:-60}"
+GIT_SYNC_COMMAND="${GIT_SYNC_COMMAND:-git-sync}"
+
+# Initialize the directory
+if [ ! -d  "$GIT_SYNC_DIRECTORY" ]; then
+	if [ -z $value ]; then
+		echo "Please specify a value for GIT_SYNC_REPOSITORY in order to initialize the git repository"
+		exit 1
+	else
+	    base="$(dirname $GIT_SYNC_DIRECTORY)"
+		mkdir -p "$base"
+		cd "$base"
+		git clone "$GIT_SYNC_REPOSITORY" "$(basename $GIT_SYNC_DIRECTORY)"
+	fi
+fi
+
+cd "$GIT_SYNC_DIRECTORY"
+
+echo "Syncing $(git remote get-url $(git remote | head -n 1 )) at $(pwd) with a default sync interval of $GIT_SYNC_INTERVAL"
+
+while true; do
+	changedFile=$(
+		inotifywait ./ -r -e modify,move,create,delete \
+			--format "%w%f" --exclude '\.git' -t "$GIT_SYNC_INTERVAL" 2>/dev/null
+	)
+	if [ -z "$changedFile" ]
+	then
+		echo "Syncing due to timeout"
+		$GIT_SYNC_COMMAND -n -s
+	else
+		echo "Syncing for: $changedFile"
+		{ git check-ignore "$changedFile" > /dev/null; } || $GIT_SYNC_COMMAND -n -s
+	fi
+done

--- a/git-sync-on-inotify
+++ b/git-sync-on-inotify
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 GIT_SYNC_DIRECTORY="${GIT_SYNC_DIRECTORY:-$(pwd)}"
-GIT_SYNC_INTERVAL="${GIT_SYNC_INTERVAL:-60}"
 GIT_SYNC_COMMAND="${GIT_SYNC_COMMAND:-git-sync}"
+GIT_SYNC_INTERVAL="${GIT_SYNC_INTERVAL:-500}"
 
 # Initialize the directory
 if [ ! -d  "$GIT_SYNC_DIRECTORY" ]; then
@@ -19,7 +19,7 @@ fi
 
 cd "$GIT_SYNC_DIRECTORY"
 
-echo "Syncing $(git remote get-url $(git remote | head -n 1 )) at $(pwd) with a default sync interval of $GIT_SYNC_INTERVAL"
+echo "Syncing $(git remote get-url $(git config --get branch.$branch_name.pushRemote)) at $(pwd) with a default sync interval of $GIT_SYNC_INTERVAL"
 
 while true; do
 	changedFile=$(


### PR DESCRIPTION
Wrote a simple script to perpetually monitor a git repository for changes using the inotifywait tool.

Though it is pretty short, it handles a few small gotchas that some users may not catch like:

- Not doing anything when the file changes is gitignored
- ignoring the .git directory
- redirecting output

If you don't think this is useful, feel free discard