### PR TITLE
Double-quote $PWD in __gitdir() - path may contain spaces

### DIFF
--- a/git-sync
+++ b/git-sync
@@ -61,8 +61,8 @@ __log_msg()
 # echo the git dir
 __gitdir()
 {
-	if [ "true" = "$(git rev-parse --is-inside-work-tree $PWD | head -1)" ]; then
-		git rev-parse --git-dir $PWD 2>/dev/null
+	if [ "true" = "$(git rev-parse --is-inside-work-tree "$PWD" | head -1)" ]; then
+		git rev-parse --git-dir "$PWD" 2>/dev/null
 	fi
 }
 


### PR DESCRIPTION
__gitdir() fails when the path contains a space. Putting $PWD inside double quotes fixes this problem.

Thanks for this script. It has been very useful for me!