### PR TITLE
Change sync behaviour with command-line flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git and bash, but does not even try to shield you from git. It is
 non-interactive, but will cautiously exit with a useful hint or error
 if there is any kind of problem.
 
-It is ultimately intended for git-savy people. As a rule of thumb, if
+It is ultimately intended for git-savvy people. As a rule of thumb, if
 you know how to complete a failed rebase, you're fine.
 
 For a really nice explanation in an advanced use case, have a look at this blog post:

--- a/README.md
+++ b/README.md
@@ -126,6 +126,24 @@ Or if you enable `syncNewFiles`:
 
     git add -A ; git commit -m \"changes from $(uname -n) on $(date)\";"
 
+### Command-line flags
+
+There are also some command-line flags you can set to control the sync:
+
+`-n` is the equivalent of `branch.$branch_name.syncNewFiles`, adding new files
+even if the matching `git config` option is not set.
+
+`-s` is the equivalent of `branch.$branch_name.sync`, allowing syncing a branch
+even if the matching `git config` option is not set.
+
+`-p` controls how the choice of remote to use for backing up. If it is set,
+then instead of simply relying on `branch.$branch_name.remote` to select the
+backup remote, the script uses also considers the branch's pushRemote. As
+explained [in the docs](https://git-scm.com/docs/git-config), there are three
+`git config` options that specify the remote to push to by default, with
+`branch.$branch_name.pushRemote` overriding `remote.pushDefault` which in turn
+overrides `branch.$branch_name.remote`. The `-p` flag adopts this logic.
+
 # License
 
 I declare this work to be useable under the provisions of the CC0 license.

--- a/git-sync
+++ b/git-sync
@@ -49,7 +49,7 @@ DEFAULT_AUTOCOMMIT_MSG="changes from $(uname -n) on $(date)"
 
 print_usage() {
     cat << EOF
-usage: $0 [-h] [-p] [MODE]
+usage: $0 [-h] [-p] [-s] [MODE]
 
 Synchronize the current branch to a remote backup
 MODE may be either "sync" (the default) or "check", to verify that the branch is ready to sync
@@ -57,12 +57,14 @@ MODE may be either "sync" (the default) or "check", to verify that the branch is
 OPTIONS:
    -h      Show this message
    -p      Try to sync with the pushRemote remote, when possible
+   -s      Sync the branch even if branch.\$branch_name.sync isn't set
 EOF
 }
 
 preferred_remote="upstream"
+sync_anyway="false"
 
-while getopts "hp" opt ; do
+while getopts "hps" opt ; do
     case $opt in
         h )
             print_usage
@@ -70,6 +72,9 @@ while getopts "hp" opt ; do
             ;;
         p )
             preferred_remote="pushRemote"
+            ;;
+        s )
+            sync_anyway="true"
             ;;
     esac
 done
@@ -258,7 +263,7 @@ if [ -z "$remote_name" ] ; then
 fi
 
 # check if current branch is configured for sync
-if [ "true" != "$(git config --get --bool branch.$branch_name.sync)" ] ; then
+if [[ "true" != "$(git config --get --bool branch.$branch_name.sync)" && "true" != "$sync_anyway" ]] ; then
     echo
     __log_msg "Please use"
     echo

--- a/git-sync
+++ b/git-sync
@@ -49,26 +49,30 @@ DEFAULT_AUTOCOMMIT_MSG="changes from $(uname -n) on $(date)"
 
 print_usage() {
     cat << EOF
-usage: $0 [-h] [-p] [-s] [MODE]
+usage: $0 [-h] [-n] [-p] [-s] [MODE]
 
 Synchronize the current branch to a remote backup
 MODE may be either "sync" (the default) or "check", to verify that the branch is ready to sync
 
 OPTIONS:
    -h      Show this message
+   -n      Commit new files even if branch.\$branch_name.syncNewFiles isn't set
    -p      Try to sync with the pushRemote remote, when possible
    -s      Sync the branch even if branch.\$branch_name.sync isn't set
 EOF
 }
-
+sync_new_files_anyway="false"
 preferred_remote="upstream"
 sync_anyway="false"
 
-while getopts "hps" opt ; do
+while getopts "hnps" opt ; do
     case $opt in
         h )
             print_usage
             exit 0
+            ;;
+        n )
+            sync_new_files_anyway="true"
             ;;
         p )
             preferred_remote="pushRemote"
@@ -148,7 +152,7 @@ git_repo_state ()
 check_initial_file_state()
 {
     local syncNew="$(git config --get --bool branch.$branch_name.syncNewFiles)"
-    if [ "true" == "$syncNew" ]; then
+    if [[ "true" == "$syncNew" || "true" == "$sync_new_files_anyway" ]]; then
 	# allow for new files
 	if [ ! -z "$(git status --porcelain | grep -E '^[^ \?][^M\?] *')" ]; then
 	    echo "NonNewOrModified"
@@ -314,7 +318,7 @@ if [ ! -z "$(local_changes)" ]; then
     # discern the three ways to auto-commit
     if [ ! -z "$config_autocommit_cmd" ]; then
 	autocommit_cmd="$config_autocommit_cmd"
-    elif [ "true" == "$(git config --get --bool branch.$branch_name.syncNewFiles)" ]; then
+    elif [[ "true" == "$(git config --get --bool branch.$branch_name.syncNewFiles)" || "true" == "$sync_new_files_anyway" ]]; then
 	autocommit_cmd=${ALL_AUTOCOMMIT_CMD}
     else
         autocommit_cmd=${DEFAULT_AUTOCOMMIT_CMD}

--- a/git-sync
+++ b/git-sync
@@ -49,21 +49,27 @@ DEFAULT_AUTOCOMMIT_MSG="changes from $(uname -n) on $(date)"
 
 print_usage() {
     cat << EOF
-usage: $0 [-h] [MODE]
+usage: $0 [-h] [-p] [MODE]
 
 Synchronize the current branch to a remote backup
 MODE may be either "sync" (the default) or "check", to verify that the branch is ready to sync
 
 OPTIONS:
    -h      Show this message
+   -p      Try to sync with the pushRemote remote, when possible
 EOF
 }
 
-while getopts "h" opt ; do
+preferred_remote="upstream"
+
+while getopts "hp" opt ; do
     case $opt in
         h )
             print_usage
             exit 0
+            ;;
+        p )
+            preferred_remote="pushRemote"
             ;;
     esac
 done
@@ -227,7 +233,17 @@ if [ -z "$branch_name" ] ; then
 fi
 
 # while at it, determine the remote to operate on
-remote_name=$(git config --get branch.$branch_name.remote)
+if [[ "pushRemote" == "$preferred_remote" ]] ; then
+    remote_name=$(git config --get branch.$branch_name.pushRemote)
+    if [ -z "$remote_name" ] ; then
+        remote_name=$(git config --get remote.pushDefault)
+    fi
+    if [ -z "$remote_name" ] ; then
+        remote_name=$(git config --get branch.$branch_name.remote)
+    fi
+else
+    remote_name=$(git config --get branch.$branch_name.remote)
+fi
 
 if [ -z "$remote_name" ] ; then
     __log_msg "the current branch does not have a configured remote."

--- a/git-sync
+++ b/git-sync
@@ -47,7 +47,27 @@ DEFAULT_AUTOCOMMIT_MSG="changes from $(uname -n) on $(date)"
 # AUTOCOMMIT_CMD="echo \"Please commit or stash pending changes\"; exit 1;"
 # TODO mode for stash push & pop
 
+print_usage() {
+    cat << EOF
+usage: $0 [-h] [MODE]
 
+Synchronize the current branch to a remote backup
+MODE may be either "sync" (the default) or "check", to verify that the branch is ready to sync
+
+OPTIONS:
+   -h      Show this message
+EOF
+}
+
+while getopts "h" opt ; do
+    case $opt in
+        h )
+            print_usage
+            exit 0
+            ;;
+    esac
+done
+shift $((OPTIND-1))
 
 #
 #    utility functions, some adapted from git bash completion


### PR DESCRIPTION
I use `git-sync` to automatically back up the code I'm writing for the company I work in. To avoid spamming the common repo with opaque commits, I've set up a personal fork to sync against, and interactively rebase a branch to clean it up before pushing to the common codebase.
To facilitate this workflow, I added a couple of command-line flags:
* `-n` and `-s` are equivalents of `branch.<name>.syncNewFiles` and `branch.<name>.sync` respectively. I use them because I open a lot of feature branches, and the flags save me the hassle of setting these config options every time.
* `-p` is the major new feature. It applies git's standardized hierarchy of remotes `branch.<name>.pushRemote` > `remote.pushDefault` > `branch.<name>.remote` (documented [here](https://git-scm.com/docs/git-config)) to choose the remote to use for backups. This allows me to set `remote.pushDefault` once, and get backups into my personal fork while keeping it easy to manually push a branch upstream when I need to.