### PR TITLE
modified to enable sync only after GIT_SYNC_INTERVAL

### DIFF
--- a/contrib/git-sync-on-inotify
+++ b/contrib/git-sync-on-inotify
@@ -3,37 +3,42 @@
 GIT_SYNC_DIRECTORY="${GIT_SYNC_DIRECTORY:-$(pwd)}"
 GIT_SYNC_COMMAND="${GIT_SYNC_COMMAND:-git-sync}"
 GIT_SYNC_INTERVAL="${GIT_SYNC_INTERVAL:-500}"
+GIT_SLEEP_TIME=$((GIT_SYNC_INTERVAL - 10))
+
 
 # Initialize the directory
 if [ ! -d  "$GIT_SYNC_DIRECTORY" ]; then
-	if [ -z "$GIT_SYNC_REPOSITORY" ]; then
-		echo "Please specify a value for GIT_SYNC_REPOSITORY in order to initialize the git repository"
-		exit 1
-	else
-	    base="$(dirname $GIT_SYNC_DIRECTORY)"
-		mkdir -p "$base"
-		cd "$base"
-		git clone "$GIT_SYNC_REPOSITORY" "$(basename $GIT_SYNC_DIRECTORY)"
-	fi
+        if [ -z "$GIT_SYNC_REPOSITORY" ]; then
+                echo "Please specify a value for GIT_SYNC_REPOSITORY in order to initialize the git repository"
+                exit 1
+        else
+            base="$(dirname $GIT_SYNC_DIRECTORY)"
+                mkdir -p "$base"
+                cd "$base"
+                git clone "$GIT_SYNC_REPOSITORY" "$(basename $GIT_SYNC_DIRECTORY)"
+        fi
 fi
 
 cd "$GIT_SYNC_DIRECTORY"
 
-remote_name=$(git config --get branch.$(basename $(git symbolic-ref -q HEAD)).pushRemote)
+remote_name=$(git config --get branch.$(basename $(git symbolic-ref -q HEAD)).remote)
 
-echo "Syncing $(git remote get-url $remote_name) at $(pwd) with a default sync interval of $GIT_SYNC_INTERVAL"
+echo "Syncing $(git remote get-url $remote_name) at $(pwd) with a default sync interval of $GIT_SYNC_INTERVAL and a sleep time of $GIT_SLEEP_TIME"
+
+last_sync=$(date +%s)
 
 while true; do
-	changedFile=$(
-		inotifywait "$GIT_SYNC_DIRECTORY" -r -e modify,move,create,delete \
-			--format "%w%f" --exclude '\.git' -t "$GIT_SYNC_INTERVAL" 2>/dev/null
-	)
-	if [ -z "$changedFile" ]
-	then
-		echo "Syncing due to timeout"
-		$GIT_SYNC_COMMAND -n -s
-	else
-		echo "Syncing for: $changedFile"
-		{ git check-ignore "$changedFile" > /dev/null; } || $GIT_SYNC_COMMAND -n -s
-	fi
+        changedFile=$(
+                inotifywait "$GIT_SYNC_DIRECTORY" -r -e modify,move,create,delete \
+                        --format "%w%f" --exclude '\.git' -t "$GIT_SYNC_INTERVAL" 2>/dev/null
+        )
+        current_time=$(date +%s)
+        time_since_last_sync=$((current_time - last_sync))
+
+        if [ ! -z "$changedFile" ] && [ $time_since_last_sync -ge $GIT_SLEEP_TIME ]
+        then
+                echo "Syncing for: $changedFile"
+                { git check-ignore "$changedFile" > /dev/null; } || $GIT_SYNC_COMMAND -n -s
+                last_sync=$(date +%s)
+        fi
 done


### PR DESCRIPTION
The current implementation of git-sync-on-inotify syncs continuously whenever an edit is made. This modification ensures that the sync waits until GIT_SYNC_INTERVAL until the next sync is made, thus reducing the number of commits