### PR TITLE
Add branch-independent counterparts to configuration flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,13 @@ name and time by default.
 
 There are several `git config`-based options for tailoring your sync:
 
-    branch.$branch_name.syncNewFiles (bool)
+    branch.$branch_name.syncNewFiles (bool) and git-sync.syncNewFiles (bool)
 
 Tells git-sync to invoke auto-commit even if new (untracked) files are
-present. Normally you have to commit those yourself to prevent
-accidental additions. git-sync will exit at stage 3 with an
-explanation in that case.
+present. Normally you have to commit those yourself to prevent accidental
+additions. git-sync will exit at stage 3 with an explanation in that case. Both
+flags have the same meaning, and the branch-specific one can be used to override
+the settings of the generic flag on a per-branch basis.
 
     branch.$branch_name.syncSkipHooks (bool) and git-sync.syncSkipHooks (bool)
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ name and time by default.
 
 There are several `git config`-based options for tailoring your sync:
 
+    branch.$branch_name.sync (bool) and git-sync.syncEnabled (bool)
+
+Configures the branch for sync. Without one of these two (or the equivalent `-s`
+command-line flag) git-sync will refuse to perform automated modifications of
+the repository. Both flags have the same meaning, and the branch-specific one
+can be used to override the settings of the generic flag on a per-branch basis.
+
     branch.$branch_name.syncNewFiles (bool) and git-sync.syncNewFiles (bool)
 
 Tells git-sync to invoke auto-commit even if new (untracked) files are

--- a/git-sync
+++ b/git-sync
@@ -89,10 +89,28 @@ __gitdir()
 	fi
 }
 
+__syncnew_flag()
+{
+    if [[ "true" == "$sync_new_files_anyway" ]]; then
+        echo "true"
+        return
+    fi
+
+    syncnew_flag="$(git config --get --bool branch.$branch_name.syncNewFiles)"
+    if [ -z "$syncnew_flag" ] ; then
+        syncnew_flag="$(git config --get --bool git-sync.syncNewFiles)"
+    fi
+    if [ -z "$syncnew_flag" ] ; then
+        syncnew_flag="false"
+    fi
+
+    echo "$syncnew_flag"
+}
+
 # compose the add step command
 __gitadd()
 {
-    if [[ "true" == "$(git config --get --bool branch.$branch_name.syncNewFiles)" || "true" == "$sync_new_files_anyway" ]]; then
+    if [[ "true" == "$(__syncnew_flag)" ]]; then
         echo git add -A
     else
         echo git add -u
@@ -167,8 +185,7 @@ git_repo_state ()
 # check if we only have untouched, modified or (if configured) new files
 check_initial_file_state()
 {
-    local syncNew="$(git config --get --bool branch.$branch_name.syncNewFiles)"
-    if [[ "true" == "$syncNew" || "true" == "$sync_new_files_anyway" ]]; then
+    if [[ "true" == "$(__syncnew_flag)" ]]; then
 	# allow for new files
 	if [ ! -z "$(git status --porcelain | grep -E '^[^ \?][^M\?] *')" ]; then
 	    echo "NonNewOrModified"

--- a/git-sync
+++ b/git-sync
@@ -107,6 +107,24 @@ __syncnew_flag()
     echo "$syncnew_flag"
 }
 
+__sync_flag()
+{
+    if [[ "true" == "$sync_anyway" ]]; then
+        echo "true"
+        return
+    fi
+
+    sync_flag="$(git config --get --bool branch.$branch_name.sync)"
+    if [ -z "$sync_flag" ] ; then
+        sync_flag="$(git config --get --bool git-sync.syncEnabled)"
+    fi
+    if [ -z "$sync_flag" ] ; then
+        sync_flag="false"
+    fi
+
+    echo "$sync_flag"
+}
+
 # compose the add step command
 __gitadd()
 {
@@ -296,7 +314,7 @@ if [ -z "$remote_name" ] ; then
 fi
 
 # check if current branch is configured for sync
-if [[ "true" != "$(git config --get --bool branch.$branch_name.sync)" && "true" != "$sync_anyway" ]] ; then
+if [[ "true" != "$(__sync_flag)" ]] ; then
     echo
     __log_msg "Please use"
     echo


### PR DESCRIPTION
This allows a configuring the script in a set-once fashion that applies to all branches. Each branch-independent flag can still be overridden by setting the traditional branch-specific variant